### PR TITLE
Set kernel_interface_ready for loopback

### DIFF
--- a/ops-tests/component/test_portd_ct_lpbk_subif_test_cases.py
+++ b/ops-tests/component/test_portd_ct_lpbk_subif_test_cases.py
@@ -131,8 +131,6 @@ def portd(sw1, step):
     sw1("interface loopback 1")
     sw1("exit")
     cmnd = "ip netns exec swns ifconfig loopback1"
-    #out = sw1(cmnd, shell='bash')
-    #assert "loopback1" in out
     # configuring the ip address and verifying
     sw1("interface loopback 1")
     sw1("ip address 192.168.1.5/24")

--- a/ops-tests/component/test_portd_ct_lpbk_subif_test_cases.py
+++ b/ops-tests/component/test_portd_ct_lpbk_subif_test_cases.py
@@ -130,15 +130,20 @@ def portd(sw1, step):
     # enabling the loopback interface
     sw1("interface loopback 1")
     sw1("exit")
-    cmnd = "ip netns exec swns ifconfig lo:1"
-    sw1(cmnd, shell='bash')
-    # assert "lo:1" in output
+    cmnd = "ip netns exec swns ifconfig loopback1"
+    #out = sw1(cmnd, shell='bash')
+    #assert "loopback1" in out
     # configuring the ip address and verifying
     sw1("interface loopback 1")
     sw1("ip address 192.168.1.5/24")
     sw1("exit")
-    sw1(cmnd, shell='bash')
-    # assert "inet addr:192.168.1.5" in output
+    # portd needs time to react and create the interface in the kernel
+    sleep(5)
+    out = sw1(cmnd, shell='bash')
+    assert "inet addr:192.168.1.5" in out
+    # verifying "kernel_interface_ready" == "true"
+    out = sw1("get port loopback1 kernel_interface_ready", shell="vsctl")
+    assert "true" in out
     # verifying ping from host
     sw1("ping -c 5 192.168.1.5", shell='bash')
     sleep(2)

--- a/src/portd.c
+++ b/src/portd.c
@@ -226,7 +226,7 @@ static void portd_handle_port_config(const struct ovsrec_port *row,
                                      struct port_lag_data *portp);
 static void portd_update_interface_lag_eligibility(struct iface_data *idp);
 
-int
+bool
 portd_reconfig_ns_loopback(struct port *port,
                            struct ovsrec_port *port_row, bool create_flag);
 
@@ -3265,7 +3265,7 @@ bool portd_add_interface_netlink(struct ovsrec_port *port_row,
     return true;
 }
 
-int
+bool
 portd_reconfig_ns_loopback(struct port *port,
                            struct ovsrec_port *port_row, bool create_flag)
 {
@@ -3305,7 +3305,7 @@ portd_reconfig_ns_loopback(struct port *port,
         portd_reconfig_ipaddr(port, port_row);
     }
 
-    return EXIT_SUCCESS;
+    return true;
 }
 
 void


### PR DESCRIPTION
Set kernel_interface_ready to "true" after dummy
interface is created in kernel. It is needed for
those processes/services who needs kernel
configuration done to use the loopback.

Tags: fix, dev

Change-Id: I931e2c8ef1b1c02d39d4cb2af0ea6b23a3210d5b
Signed-off-by: Nikolay Stroykov stroykov@mera.ru
